### PR TITLE
Add full Hangul syllabary and dataset tests

### DIFF
--- a/src/HangulQuiz/Data.hs
+++ b/src/HangulQuiz/Data.hs
@@ -1,0 +1,27 @@
+module HangulQuiz.Data (pairs) where
+
+import Data.Char (chr)
+
+initials :: [String]
+initials =
+  [ "g","gg","n","d","dd","r","m","b","bb","s","ss","","j","jj","ch","k","t","p","h" ]
+
+medials :: [String]
+medials =
+  [ "a","ae","ya","yae","eo","e","yeo","ye","o","wa","wae","oe","yo","u","wo","we","wi","yu","eu","ui","i" ]
+
+finals :: [String]
+finals =
+  [ "","k","k","ks","n","nj","nh","t","l","lk","lm","lb","ls","lt","lp","lh","m","p","ps","t","t","ng","t","t","k","t","p","t" ]
+
+base :: Int
+base = 0xAC00
+
+pairs :: [(String,String)]
+pairs = [ ([chr (base + off)], romanize off) | off <- [0 .. 11171] ]
+
+romanize :: Int -> String
+romanize off =
+  let (l, mf) = off `divMod` 588
+      (m, f) = mf `divMod` 28
+   in initials !! l ++ medials !! m ++ finals !! f

--- a/src/HangulQuiz/Quiz.hs
+++ b/src/HangulQuiz/Quiz.hs
@@ -1,0 +1,12 @@
+module HangulQuiz.Quiz (randomPair, allPairs) where
+
+import HangulQuiz.Data (pairs)
+import System.Random (randomRIO)
+
+allPairs :: [(String,String)]
+allPairs = pairs
+
+randomPair :: IO (String,String)
+randomPair = do
+  i <- randomRIO (0, length pairs - 1)
+  return (pairs !! i)

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -1,0 +1,24 @@
+module Main (main) where
+
+import HangulQuiz.Data (pairs)
+import Data.List (lookup)
+import System.Exit (exitFailure)
+
+main :: IO ()
+main = do
+  let count = length pairs
+  if count /= 11172
+    then do
+      putStrLn ("Expected 11172 syllables, got " ++ show count)
+      exitFailure
+    else return ()
+  check "가" "ga"
+  check "힣" "hit"
+  putStrLn "All tests passed."
+  where
+    check s r =
+      case lookup s pairs of
+        Just v | v == r -> return ()
+        _ -> do
+          putStrLn ("Incorrect romanization for " ++ s)
+          exitFailure


### PR DESCRIPTION
## Summary
- Generate the entire Hangul syllabary with romanization in `pairs`
- Expose all pairs and random selection in quiz module
- Add tests checking syllable count and sample romanizations

## Testing
- `runhaskell -isrc test/Spec.hs`


------
https://chatgpt.com/codex/tasks/task_e_68aca0e7f7a8832493d63d8c0b458d9e