### PR TITLE
Add Haskell CI workflow

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -1,0 +1,32 @@
+name: Haskell CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Haskell
+        uses: haskell/actions/setup@v2
+        with:
+          ghc-version: latest
+          cabal-version: latest
+      - name: Cache cabal store
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cabal/packages
+            ~/.cabal/store
+          key: ${{ runner.os }}-cabal-${{ hashFiles('**/cabal.project', '**/*.cabal') }}
+          restore-keys: ${{ runner.os }}-cabal-
+      - name: Update dependencies
+        run: cabal update
+      - name: Build
+        run: cabal build
+      - name: Test
+        run: cabal test


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to build and test Haskell projects with cabal

## Testing
- `cabal test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aca0f387c48324a7168f9749044ce3