### PR TITLE
Refactor Hangul data generation

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -1,0 +1,32 @@
+name: Haskell CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Haskell
+        uses: haskell/actions/setup@v2
+        with:
+          ghc-version: latest
+          cabal-version: latest
+      - name: Cache cabal store
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cabal/packages
+            ~/.cabal/store
+          key: ${{ runner.os }}-cabal-${{ hashFiles('**/cabal.project', '**/*.cabal') }}
+          restore-keys: ${{ runner.os }}-cabal-
+      - name: Update dependencies
+        run: cabal update
+      - name: Build
+        run: cabal build
+      - name: Test
+        run: cabal test

--- a/cabal.project
+++ b/cabal.project
@@ -1,0 +1,2 @@
+packages: .
+index-state: 2024-01-01T00:00:00Z

--- a/src/HangulQuiz/Data.hs
+++ b/src/HangulQuiz/Data.hs
@@ -1,6 +1,4 @@
-module HangulQuiz.Data (pairs) where
-
-import Data.Char (chr)
+module HangulQuiz.Data (initials, medials, finals, romanize) where
 
 initials :: [String]
 initials =
@@ -13,12 +11,6 @@ medials =
 finals :: [String]
 finals =
   [ "","k","k","ks","n","nj","nh","t","l","lk","lm","lb","ls","lt","lp","lh","m","p","ps","t","t","ng","t","t","k","t","p","t" ]
-
-base :: Int
-base = 0xAC00
-
-pairs :: [(String,String)]
-pairs = [ ([chr (base + off)], romanize off) | off <- [0 .. 11171] ]
 
 romanize :: Int -> String
 romanize off =

--- a/src/HangulQuiz/Data.hs
+++ b/src/HangulQuiz/Data.hs
@@ -1,0 +1,27 @@
+module HangulQuiz.Data (pairs) where
+
+import Data.Char (chr)
+
+initials :: [String]
+initials =
+  [ "g","gg","n","d","dd","r","m","b","bb","s","ss","","j","jj","ch","k","t","p","h" ]
+
+medials :: [String]
+medials =
+  [ "a","ae","ya","yae","eo","e","yeo","ye","o","wa","wae","oe","yo","u","wo","we","wi","yu","eu","ui","i" ]
+
+finals :: [String]
+finals =
+  [ "","k","k","ks","n","nj","nh","t","l","lk","lm","lb","ls","lt","lp","lh","m","p","ps","t","t","ng","t","t","k","t","p","t" ]
+
+base :: Int
+base = 0xAC00
+
+pairs :: [(String,String)]
+pairs = [ ([chr (base + off)], romanize off) | off <- [0 .. 11171] ]
+
+romanize :: Int -> String
+romanize off =
+  let (l, mf) = off `divMod` 588
+      (m, f) = mf `divMod` 28
+   in initials !! l ++ medials !! m ++ finals !! f

--- a/src/HangulQuiz/Quiz.hs
+++ b/src/HangulQuiz/Quiz.hs
@@ -1,12 +1,22 @@
 module HangulQuiz.Quiz (randomPair, allPairs) where
 
-import HangulQuiz.Data (pairs)
+import HangulQuiz.Data (romanize)
+import Data.Char (chr)
 import System.Random (randomRIO)
 
+base :: Int
+base = 0xAC00
+
+syllableCount :: Int
+syllableCount = 11172
+
+pairAt :: Int -> (String, String)
+pairAt off = ([chr (base + off)], romanize off)
+
 allPairs :: [(String,String)]
-allPairs = pairs
+allPairs = map pairAt [0 .. syllableCount - 1]
 
 randomPair :: IO (String,String)
 randomPair = do
-  i <- randomRIO (0, length pairs - 1)
-  return (pairs !! i)
+  i <- randomRIO (0, syllableCount - 1)
+  return (pairAt i)

--- a/src/HangulQuiz/Quiz.hs
+++ b/src/HangulQuiz/Quiz.hs
@@ -1,0 +1,12 @@
+module HangulQuiz.Quiz (randomPair, allPairs) where
+
+import HangulQuiz.Data (pairs)
+import System.Random (randomRIO)
+
+allPairs :: [(String,String)]
+allPairs = pairs
+
+randomPair :: IO (String,String)
+randomPair = do
+  i <- randomRIO (0, length pairs - 1)
+  return (pairs !! i)

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -1,0 +1,24 @@
+module Main (main) where
+
+import HangulQuiz.Data (pairs)
+import Data.List (lookup)
+import System.Exit (exitFailure)
+
+main :: IO ()
+main = do
+  let count = length pairs
+  if count /= 11172
+    then do
+      putStrLn ("Expected 11172 syllables, got " ++ show count)
+      exitFailure
+    else return ()
+  check "가" "ga"
+  check "힣" "hit"
+  putStrLn "All tests passed."
+  where
+    check s r =
+      case lookup s pairs of
+        Just v | v == r -> return ()
+        _ -> do
+          putStrLn ("Incorrect romanization for " ++ s)
+          exitFailure

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -1,12 +1,12 @@
 module Main (main) where
 
-import HangulQuiz.Data (pairs)
+import HangulQuiz.Quiz (allPairs)
 import Data.List (lookup)
 import System.Exit (exitFailure)
 
 main :: IO ()
 main = do
-  let count = length pairs
+  let count = length allPairs
   if count /= 11172
     then do
       putStrLn ("Expected 11172 syllables, got " ++ show count)
@@ -17,7 +17,7 @@ main = do
   putStrLn "All tests passed."
   where
     check s r =
-      case lookup s pairs of
+      case lookup s allPairs of
         Just v | v == r -> return ()
         _ -> do
           putStrLn ("Incorrect romanization for " ++ s)


### PR DESCRIPTION
## Summary
- generate Hangul syllables programmatically and expose romanization pieces
- compute quiz pairs on demand using the romanize function
- update tests to use the new allPairs API

## Testing
- `runghc -isrc test/Spec.hs`


------
https://chatgpt.com/codex/tasks/task_e_68aca9f1f204832499ab2feb52ac6aa7