### PR TITLE
Add Hspec tests for quiz data and random pair

### DIFF
--- a/hangul-quiz.cabal
+++ b/hangul-quiz.cabal
@@ -1,0 +1,21 @@
+cabal-version:       2.4
+name:                hangul-quiz
+version:             0.1.0.0
+build-type:          Simple
+
+library
+  hs-source-dirs:      src
+  exposed-modules:     HangulQuiz.Data, HangulQuiz.Quiz
+  build-depends:       base >=4.7 && <5,
+                       random
+  default-language:    Haskell2010
+
+test-suite spec
+  type:              exitcode-stdio-1.0
+  hs-source-dirs:    test
+  main-is:           Spec.hs
+  build-depends:     base,
+                     hangul-quiz,
+                     hspec,
+                     random
+  default-language:  Haskell2010

--- a/src/HangulQuiz/Data.hs
+++ b/src/HangulQuiz/Data.hs
@@ -1,4 +1,4 @@
-module HangulQuiz.Data (pairs) where
+module HangulQuiz.Data (pairs, romanize) where
 
 import Data.Char (chr)
 

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -1,24 +1,22 @@
 module Main (main) where
 
-import HangulQuiz.Data (pairs)
-import Data.List (lookup)
-import System.Exit (exitFailure)
+import Test.Hspec
+import HangulQuiz.Data (romanize)
+import HangulQuiz.Quiz (randomPair, allPairs)
 
 main :: IO ()
-main = do
-  let count = length pairs
-  if count /= 11172
-    then do
-      putStrLn ("Expected 11172 syllables, got " ++ show count)
-      exitFailure
-    else return ()
-  check "가" "ga"
-  check "힣" "hit"
-  putStrLn "All tests passed."
-  where
-    check s r =
-      case lookup s pairs of
-        Just v | v == r -> return ()
-        _ -> do
-          putStrLn ("Incorrect romanization for " ++ s)
-          exitFailure
+main = hspec $ do
+  describe "allPairs" $ do
+    it "contains 11172 entries" $
+      length allPairs `shouldBe` 11172
+  describe "randomPair" $ do
+    it "returns a pair from allPairs" $ do
+      p <- randomPair
+      p `shouldSatisfy` (`elem` allPairs)
+  describe "romanize" $ do
+    it "romanizes first syllable" $
+      romanize 0 `shouldBe` "ga"
+    it "romanizes second syllable" $
+      romanize 1 `shouldBe` "gak"
+    it "romanizes last syllable" $
+      romanize 11171 `shouldBe` "hit"


### PR DESCRIPTION
## Summary
- Replace ad-hoc test executable with Hspec suite
- Verify allPairs size, randomPair membership and romanize output
- Export romanize and add cabal file including random dependency

## Testing
- `cabal test`

------
https://chatgpt.com/codex/tasks/task_e_68aca9f572e88324bfc5be4312f6b723