### PR TITLE
Add GitHub CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Haskell
+        uses: haskell/actions/setup@v2
+        with:
+          ghc-version: latest
+          cabal-version: latest
+      - name: Update dependencies
+        run: cabal update
+      - name: Run tests
+        run: cabal test


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to install GHC/Cabal and run cabal tests

## Testing
- `cabal update`
- `cabal test`


------
https://chatgpt.com/codex/tasks/task_e_68accb75a1ac8324ba407dd18529ca61