### PR TITLE
Use base-4.18.0.0

### DIFF
--- a/hangul-quiz.cabal
+++ b/hangul-quiz.cabal
@@ -57,7 +57,7 @@ library
     import:           warnings
     hs-source-dirs:   src
     exposed-modules:  HangulQuiz.Data, HangulQuiz.Quiz
-    build-depends:    base ^>=4.17.2.0,
+    build-depends:    base ^>=4.18.0.0,
                       random
     default-language: Haskell2010
 
@@ -65,7 +65,7 @@ executable hangul-quiz
     import:           warnings
     hs-source-dirs:   app
     main-is:          Main.hs
-    build-depends:    base ^>=4.17.2.0,
+    build-depends:    base ^>=4.18.0.0,
                       random,
                       hangul-quiz
     default-language: Haskell2010
@@ -75,7 +75,7 @@ test-suite hangul-quiz-test
     type:             exitcode-stdio-1.0
     hs-source-dirs:   test
     main-is:          Spec.hs
-    build-depends:    base ^>=4.17.2.0,
+    build-depends:    base ^>=4.18.0.0,
                       hspec,
                       QuickCheck,
                       random,


### PR DESCRIPTION
## Summary
- require base 4.18 for library, executable and tests

## Testing
- `cabal test` *(fails: base^>=4.18.0.0 requires newer GHC)*

------
https://chatgpt.com/codex/tasks/task_e_68ace0a62070832491b4e739ca8db399