### PR TITLE
Fix cabal jobs flag in CI workflow

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -30,7 +30,7 @@ jobs:
         run: cabal update
 
       - name: Build
-        run: cabal build --jobs=${{ env.BUILD_JOBS || '' }}
+        run: cabal build ${BUILD_JOBS:+--jobs=$BUILD_JOBS}
 
       - name: Run tests
         run: cabal test --test-show-details=direct


### PR DESCRIPTION
## Summary
- avoid passing an empty jobs option to `cabal build`

## Testing
- `cabal test` *(fails: base dependency requires GHC with base>=4.18)*

------
https://chatgpt.com/codex/tasks/task_e_68ad6ef6979c8324b939d2aa57e1e78b