### PR TITLE
Add command line options for Hangul quiz

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,18 @@ Ce projet fournit un petit quiz en ligne de commande pour pratiquer le syllabair
 ## Utilisation
 
 ```bash
-cabal run
+cabal run hangul-quiz -- [options]
 ```
 
-Le programme pose trois questions aléatoires et affiche le score final.
+Le programme pose par défaut trois questions aléatoires et affiche le score final.
+
+Options disponibles :
+
+- `-n N`, `--tests N` : nombre de questions (utiliser `inf` pour un quiz infini).
+- `-d DIR`, `--direction DIR` : sens des questions : `st` (syllabe → transcription),
+  `ts` (transcription → syllabe) ou `both`.
+
+Pendant un quiz infini, tapez `:q` pour quitter.
 
 ## Tests
 

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -1,26 +1,57 @@
 module Main where
 
+import System.Environment (getArgs)
+import Text.Read (readMaybe)
 import System.Random (getStdGen, StdGen)
 import HangulQuiz.Quiz
 
--- | Run a short quiz of three questions.
+-- | Run the quiz according to command line options.
 main :: IO ()
 main = do
-  putStrLn "Hangul Quiz!"
+  putStrLn "Hangul Quiz! (type :q to quit)"
+  args <- getArgs
+  let (mCount, dir) = parseArgs args
   gen <- getStdGen
-  (score, _) <- runQuiz 3 gen 0
-  putStrLn ("Score: " ++ show score ++ "/3")
+  (score, asked, _) <- runQuiz mCount dir gen 0 0
+  putStrLn ("Score: " ++ show score ++ "/" ++ show asked)
 
--- | Ask N questions accumulating the score.
-runQuiz :: Int -> StdGen -> Int -> IO (Int, StdGen)
-runQuiz 0 gen score = pure (score, gen)
-runQuiz n gen score = do
+-- | Ask questions accumulating the score.
+--   The first parameter is 'Nothing' for infinite quizzes.
+runQuiz :: Maybe Int -> Direction -> StdGen -> Int -> Int -> IO (Int, Int, StdGen)
+runQuiz (Just 0) _ gen score asked = pure (score, asked, gen)
+runQuiz count dir gen score asked = do
   let (p, gen1) = randomPair gen
-      (q, gen2) = randomQuestion gen1 p
+      (q, gen2) = randomQuestion gen1 p dir
   putStrLn (prompt q)
   ans <- getLine
-  let correct = checkAnswer q ans
-  putStrLn (if correct
-              then "Correct!"
-              else "Wrong. Correct answer: " ++ correctAnswer q)
-  runQuiz (n-1) gen2 (if correct then score + 1 else score)
+  if ans == ":q"
+    then pure (score, asked, gen2)
+    else do
+      let correct = checkAnswer q ans
+      putStrLn (if correct
+                  then "Correct!"
+                  else "Wrong. Correct answer: " ++ correctAnswer q)
+      runQuiz (fmap (\n -> n - 1) count) dir gen2 (if correct then score + 1 else score) (asked + 1)
+
+-- | Parse command line arguments into (number of questions, direction).
+parseArgs :: [String] -> (Maybe Int, Direction)
+parseArgs = go (Just 3) Both
+  where
+    go n d [] = (n, d)
+    go n d ("-n":x:xs) = go (parseCount x n) d xs
+    go n d ("--tests":x:xs) = go (parseCount x n) d xs
+    go n d ("-d":x:xs) = go n (parseDir x d) xs
+    go n d ("--direction":x:xs) = go n (parseDir x d) xs
+    go n d (_:xs) = go n d xs
+
+    parseCount s def
+      | s `elem` ["inf", "infinite"] = Nothing
+      | otherwise = case readMaybe s of
+          Just v  -> Just v
+          Nothing -> def
+
+    parseDir s _
+      | s `elem` ["st", "syllable"] = ToTranscription
+      | s `elem` ["ts", "transcription"] = ToSyllable
+      | s == "both" = Both
+    parseDir _ def = def

--- a/hangul-quiz.cabal
+++ b/hangul-quiz.cabal
@@ -57,7 +57,7 @@ library
     import:           warnings
     hs-source-dirs:   src
     exposed-modules:  HangulQuiz.Data, HangulQuiz.Quiz
-    build-depends:    base ^>=4.18.0.0,
+    build-depends:    base >=4.17 && <4.19,
                       random
     default-language: Haskell2010
 
@@ -65,7 +65,7 @@ executable hangul-quiz
     import:           warnings
     hs-source-dirs:   app
     main-is:          Main.hs
-    build-depends:    base ^>=4.18.0.0,
+    build-depends:    base >=4.17 && <4.19,
                       random,
                       hangul-quiz
     default-language: Haskell2010
@@ -75,7 +75,7 @@ test-suite hangul-quiz-test
     type:             exitcode-stdio-1.0
     hs-source-dirs:   test
     main-is:          Spec.hs
-    build-depends:    base ^>=4.18.0.0,
+    build-depends:    base >=4.17 && <4.19,
                       hspec,
                       QuickCheck,
                       random,

--- a/src/HangulQuiz/Quiz.hs
+++ b/src/HangulQuiz/Quiz.hs
@@ -1,5 +1,6 @@
 module HangulQuiz.Quiz
   ( Question(..)
+  , Direction(..)
   , randomPair
   , randomQuestion
   , checkAnswer
@@ -16,15 +17,24 @@ data Question
   | AskSyllable Pair      -- ^ Show a transcription and ask for the syllable.
   deriving (Eq, Show)
 
+-- | Choose which kind of question to ask.
+data Direction
+  = ToTranscription -- ^ Ask for the transcription given a syllable.
+  | ToSyllable      -- ^ Ask for the syllable given a transcription.
+  | Both            -- ^ Ask in both directions randomly.
+  deriving (Eq, Show)
+
 -- | Pick a random syllable/transcription pair from the list.
 randomPair :: StdGen -> (Pair, StdGen)
 randomPair gen =
   let (idx, gen') = randomR (0, length pairs - 1) gen
   in (pairs !! idx, gen')
 
--- | Pick randomly whether to ask for the transcription or the syllable.
-randomQuestion :: StdGen -> Pair -> (Question, StdGen)
-randomQuestion gen p =
+-- | Pick a question according to the desired direction.
+randomQuestion :: StdGen -> Pair -> Direction -> (Question, StdGen)
+randomQuestion gen p ToTranscription = (AskTranscription p, gen)
+randomQuestion gen p ToSyllable      = (AskSyllable p, gen)
+randomQuestion gen p Both =
   let (b, gen') = randomR (0, 1 :: Int) gen
   in (if b == 0 then AskTranscription p else AskSyllable p, gen')
 

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -24,10 +24,14 @@ spec = do
       fst (randomPair (mkStdGen 0)) `shouldSatisfy` (`elem` pairs)
   describe "randomQuestion" $ do
     let p = head pairs
-    it "asks transcription when random is 0" $
-      fst (randomQuestion (mkStdGen 0) p) `shouldBe` AskTranscription p
-    it "asks syllable when random is 1" $
-      fst (randomQuestion (mkStdGen 1) p) `shouldBe` AskSyllable p
+    it "asks transcription when random is 0 in both mode" $
+      fst (randomQuestion (mkStdGen 0) p Both) `shouldBe` AskTranscription p
+    it "asks syllable when random is 1 in both mode" $
+      fst (randomQuestion (mkStdGen 1) p Both) `shouldBe` AskSyllable p
+    it "always asks transcription in ToTranscription mode" $
+      fst (randomQuestion (mkStdGen 0) p ToTranscription) `shouldBe` AskTranscription p
+    it "always asks syllable in ToSyllable mode" $
+      fst (randomQuestion (mkStdGen 0) p ToSyllable) `shouldBe` AskSyllable p
   describe "prompt and correctAnswer" $ do
     let p = Pair "가" "ga"
     it "shows syllable when asking transcription" $


### PR DESCRIPTION
## Summary
- Support `-n/--tests` to set number of questions or infinite loop, exiting with `:q`
- Add `-d/--direction` to choose question direction: syllable→transcription, transcription→syllable or both
- Document new CLI options and relax base dependency for cabal build

## Testing
- `cabal test`

------
https://chatgpt.com/codex/tasks/task_e_68ad722b0c048324863e236d88c807c3